### PR TITLE
Replace messages with data-items: fixes syncronization after reconnection

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
             android:enabled="true"
             android:exported="true">
             <intent-filter>
-                <action android:name="com.google.android.gms.wearable.MESSAGE_RECEIVED" />
+                <action android:name="com.google.android.gms.wearable.DATA_CHANGED" />
 
                 <data
                     android:host="*"

--- a/mobile/src/main/java/de/rhaeus/dndsync/DNDNotificationService.java
+++ b/mobile/src/main/java/de/rhaeus/dndsync/DNDNotificationService.java
@@ -5,23 +5,14 @@ import android.content.SharedPreferences;
 import android.service.notification.NotificationListenerService;
 import android.service.notification.StatusBarNotification;
 import android.util.Log;
-import androidx.annotation.NonNull;
-import androidx.preference.PreferenceManager;
-import com.google.android.gms.tasks.OnFailureListener;
-import com.google.android.gms.tasks.OnSuccessListener;
-import com.google.android.gms.tasks.Task;
-import com.google.android.gms.tasks.Tasks;
-import com.google.android.gms.wearable.CapabilityClient;
-import com.google.android.gms.wearable.CapabilityInfo;
-import com.google.android.gms.wearable.Node;
-import com.google.android.gms.wearable.Wearable;
 
-import java.util.Set;
-import java.util.concurrent.ExecutionException;
+import androidx.preference.PreferenceManager;
+
+import com.google.android.gms.wearable.PutDataRequest;
+import com.google.android.gms.wearable.Wearable;
 
 public class DNDNotificationService extends NotificationListenerService {
     private static final String TAG = "DNDNotificationService";
-    private static final String DND_SYNC_CAPABILITY_NAME = "dnd_sync";
     private static final String DND_SYNC_MESSAGE_PATH = "/wear-dnd-sync";
 
     public static boolean running = false;
@@ -82,53 +73,12 @@ public class DNDNotificationService extends NotificationListenerService {
     }
 
     private void sendDNDSync(int dndState) {
-        // https://developer.android.com/training/wearables/data/messages
-
-        // search nodes for sync
-        CapabilityInfo capabilityInfo = null;
-        try {
-            capabilityInfo = Tasks.await(
-                    Wearable.getCapabilityClient(this).getCapability(
-                            DND_SYNC_CAPABILITY_NAME, CapabilityClient.FILTER_REACHABLE));
-        } catch (ExecutionException e) {
-            e.printStackTrace();
-            Log.e(TAG, "execution error while searching nodes", e);
-            return;
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-            Log.e(TAG, "interruption error while searching nodes", e);
-            return;
-        }
-
-        // send request to all reachable nodes
-        // capabilityInfo has the reachable nodes with the dnd sync capability
-        Set<Node> connectedNodes = capabilityInfo.getNodes();
-        if (connectedNodes.isEmpty()) {
-            // Unable to retrieve node with transcription capability
-            Log.d(TAG, "Unable to retrieve node with sync capability!");
-        } else {
-            for (Node node : connectedNodes) {
-                if (node.isNearby()) {
-                    byte[] data = new byte[1];
-                    data[0] = (byte) dndState;
-                    Task<Integer> sendTask =
-                            Wearable.getMessageClient(this).sendMessage(node.getId(), DND_SYNC_MESSAGE_PATH, data);
-
-                    sendTask.addOnSuccessListener(new OnSuccessListener<Integer>() {
-                        @Override
-                        public void onSuccess(Integer integer) {
-                            Log.d(TAG, "send successful! Receiver node id: " + node.getId());
-                        }
-                    });
-
-                    sendTask.addOnFailureListener(new OnFailureListener() {
-                        @Override
-                        public void onFailure(@NonNull Exception e) {
-                            Log.d(TAG, "send failed! Receiver node id: " + node.getId());
-                        }
-                    });
-                }
-            }
-        }
+        // https://developer.android.com/training/wearables/data/data-items
+        Wearable.getDataClient(this)
+                .putDataItem(PutDataRequest.create(DND_SYNC_MESSAGE_PATH)
+                        .setData(new byte[]{(byte) dndState, 0})
+                        // mark urgent, otherwise it could take up to 30 minutes to sync
+                        .setUrgent()
+                );
     }
 }

--- a/mobile/src/main/java/de/rhaeus/dndsync/DNDSyncListenerService.java
+++ b/mobile/src/main/java/de/rhaeus/dndsync/DNDSyncListenerService.java
@@ -2,31 +2,27 @@ package de.rhaeus.dndsync;
 
 import android.app.NotificationManager;
 import android.content.Context;
-import android.os.Handler;
-import android.os.PowerManager;
-import android.os.VibrationEffect;
-import android.os.Vibrator;
 import android.util.Log;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 
-import com.google.android.gms.wearable.MessageEvent;
+import com.google.android.gms.wearable.DataEvent;
+import com.google.android.gms.wearable.DataEventBuffer;
 import com.google.android.gms.wearable.WearableListenerService;
 
 public class DNDSyncListenerService extends WearableListenerService {
     private static final String TAG = "DNDSyncListenerService";
-    private static final String DND_SYNC_MESSAGE_PATH = "/wear-dnd-sync";
-
 
     @Override
-    public void onMessageReceived (@NonNull MessageEvent messageEvent) {
-        Log.d(TAG, "onMessageReceived: " + messageEvent);
+    public void onDataChanged(@NonNull DataEventBuffer dataEventBuffer) {
+        Log.d(TAG, "onDataChanged: " + dataEventBuffer);
 
-        if (messageEvent.getPath().equalsIgnoreCase(DND_SYNC_MESSAGE_PATH)) {
-            Log.d(TAG, "received path: " + DND_SYNC_MESSAGE_PATH);
+        for (DataEvent dataEvent : dataEventBuffer) {
 
-            byte[] data = messageEvent.getData();
+            // No need to filter by path, it is defined in the manifest
+            // Android will make sure we only get our own messages
+
+            byte[] data = dataEvent.getDataItem().getData();
             // data[0] contains dnd mode of phone
             // 0 = INTERRUPTION_FILTER_UNKNOWN
             // 1 = INTERRUPTION_FILTER_ALL (all notifications pass)
@@ -35,6 +31,11 @@ public class DNDSyncListenerService extends WearableListenerService {
             // 4 = INTERRUPTION_FILTER_ALARMS
             byte dndStatePhone = data[0];
             Log.d(TAG, "dndStatePhone: " + dndStatePhone);
+
+            if(dndStatePhone == 5 || dndStatePhone == 6){
+                // our own dnd message, just ignore
+                continue;
+            }
 
             // get dnd state
             NotificationManager mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
@@ -52,12 +53,10 @@ public class DNDSyncListenerService extends WearableListenerService {
                     mNotificationManager.setInterruptionFilter(dndStatePhone);
                     Log.d(TAG, "DND set to " + dndStatePhone);
                 } else {
-                Log.d(TAG, "attempting to set DND but access not granted");
+                    Log.d(TAG, "attempting to set DND but access not granted");
                 }
             }
 
-        } else {
-            super.onMessageReceived(messageEvent);
         }
     }
 

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -59,7 +59,7 @@
             android:enabled="true"
             android:exported="true">
             <intent-filter>
-                <action android:name="com.google.android.gms.wearable.MESSAGE_RECEIVED" />
+                <action android:name="com.google.android.gms.wearable.DATA_CHANGED" />
 
                 <data
                     android:host="*"

--- a/wear/src/main/java/de/rhaeus/dndsync/DNDNotificationService.java
+++ b/wear/src/main/java/de/rhaeus/dndsync/DNDNotificationService.java
@@ -1,31 +1,17 @@
 package de.rhaeus.dndsync;
 
 
-import android.content.ComponentName;
 import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
 import android.service.notification.NotificationListenerService;
 import android.util.Log;
-import android.widget.Toast;
 
-import androidx.annotation.NonNull;
 import androidx.preference.PreferenceManager;
 
-import com.google.android.gms.tasks.OnFailureListener;
-import com.google.android.gms.tasks.OnSuccessListener;
-import com.google.android.gms.tasks.Task;
-import com.google.android.gms.tasks.Tasks;
-import com.google.android.gms.wearable.CapabilityClient;
-import com.google.android.gms.wearable.CapabilityInfo;
-import com.google.android.gms.wearable.Node;
+import com.google.android.gms.wearable.PutDataRequest;
 import com.google.android.gms.wearable.Wearable;
-
-import java.util.Set;
-import java.util.concurrent.ExecutionException;
 
 public class DNDNotificationService extends NotificationListenerService {
     private static final String TAG = "DNDNotificationService";
-    private static final String DND_SYNC_CAPABILITY_NAME = "dnd_sync";
     private static final String DND_SYNC_MESSAGE_PATH = "/wear-dnd-sync";
 
     public static boolean running = false;
@@ -76,53 +62,12 @@ public class DNDNotificationService extends NotificationListenerService {
     }
 
     private void sendDNDSync(int dndState) {
-        // https://developer.android.com/training/wearables/data/messages
-
-        // search nodes for sync
-        CapabilityInfo capabilityInfo = null;
-        try {
-            capabilityInfo = Tasks.await(
-                    Wearable.getCapabilityClient(this).getCapability(
-                            DND_SYNC_CAPABILITY_NAME, CapabilityClient.FILTER_REACHABLE));
-        } catch (ExecutionException e) {
-            e.printStackTrace();
-            Log.e(TAG, "execution error while searching nodes", e);
-            return;
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-            Log.e(TAG, "interruption error while searching nodes", e);
-            return;
-        }
-
-        // send request to all reachable nodes
-        // capabilityInfo has the reachable nodes with the dnd sync capability
-        Set<Node> connectedNodes = capabilityInfo.getNodes();
-        if (connectedNodes.isEmpty()) {
-            // Unable to retrieve node with transcription capability
-            Log.d(TAG, "Unable to retrieve node with sync capability!");
-        } else {
-            for (Node node : connectedNodes) {
-                if (node.isNearby()) {
-                    byte[] data = new byte[2];
-                    data[0] = (byte) dndState;
-                    Task<Integer> sendTask =
-                            Wearable.getMessageClient(this).sendMessage(node.getId(), DND_SYNC_MESSAGE_PATH, data);
-
-                    sendTask.addOnSuccessListener(new OnSuccessListener<Integer>() {
-                        @Override
-                        public void onSuccess(Integer integer) {
-                            Log.d(TAG, "send successful! Receiver node id: " + node.getId());
-                        }
-                    });
-
-                    sendTask.addOnFailureListener(new OnFailureListener() {
-                        @Override
-                        public void onFailure(@NonNull Exception e) {
-                            Log.d(TAG, "send failed! Receiver node id: " + node.getId());
-                        }
-                    });
-                }
-            }
-        }
+        // https://developer.android.com/training/wearables/data/data-items
+        Wearable.getDataClient(this)
+                .putDataItem(PutDataRequest.create(DND_SYNC_MESSAGE_PATH)
+                        .setData(new byte[]{(byte) dndState, 0})
+                        // mark urgent, otherwise it could take up to 30 minutes to sync
+                        .setUrgent()
+                );
     }
 }

--- a/wear/src/main/java/de/rhaeus/dndsync/DNDSyncListenerService.java
+++ b/wear/src/main/java/de/rhaeus/dndsync/DNDSyncListenerService.java
@@ -7,24 +7,26 @@ import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.provider.Settings;
 import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.preference.PreferenceManager;
-import com.google.android.gms.wearable.MessageEvent;
+
+import com.google.android.gms.wearable.DataEvent;
+import com.google.android.gms.wearable.DataEventBuffer;
 import com.google.android.gms.wearable.WearableListenerService;
 
 public class DNDSyncListenerService extends WearableListenerService {
     private static final String TAG = "DNDSyncListenerService";
-    private static final String DND_SYNC_MESSAGE_PATH = "/wear-dnd-sync";
 
     @Override
-    public void onMessageReceived (@NonNull MessageEvent messageEvent) {
-        if (Log.isLoggable(TAG, Log.DEBUG)) {
-            Log.d(TAG, "onMessageReceived: " + messageEvent);
-        }
+    public void onDataChanged(@NonNull DataEventBuffer dataEventBuffer) {
+        Log.d(TAG, "onDataChanged: " + dataEventBuffer);
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
 
-        if (messageEvent.getPath().equalsIgnoreCase(DND_SYNC_MESSAGE_PATH)) {
-            Log.d(TAG, "received path: " + DND_SYNC_MESSAGE_PATH);
+        for (DataEvent dataEvent : dataEventBuffer) {
+
+            // No need to filter by path, it is defined in the manifest
+            // Android will make sure we only get our own messages
 
             boolean vibrate = prefs.getBoolean("vibrate_key", false);
             Log.d(TAG, "vibrate: " + vibrate);
@@ -32,7 +34,7 @@ public class DNDSyncListenerService extends WearableListenerService {
                 vibrate();
             }
 
-            byte[] data = messageEvent.getData();
+            byte[] data = dataEvent.getDataItem().getData();
             // data[0] contains dnd mode of phone
             // 0 = INTERRUPTION_FILTER_UNKNOWN
             // 1 = INTERRUPTION_FILTER_ALL (all notifications pass)
@@ -98,9 +100,6 @@ public class DNDSyncListenerService extends WearableListenerService {
                     Log.d(TAG, "attempting to set DND but access not granted");
                 }
             }
-
-        } else {
-            super.onMessageReceived(messageEvent);
         }
     }
 


### PR DESCRIPTION
The current code uses messages to send data between the devices. These messages are also filtered to only be sent to connected devices in range.

This makes the synchronization fail if, for example, the watch is far from the phone, or if you have one of them in airplane mode, or any other situation where they are not visible from one-another.
This has the disadvantage of not syncing the state (which is expected if they don't have a connection) but it's strange that it is not synced when the connection is restored.

At first I though about simply removing the restriction of searching for connected devices in range, but android wear has a different type of connection: [data items](https://developer.android.com/training/wearables/data/data-items).

With data items you can synchronize a small amount of data (sequence of bytes, same as a message) between all available devices, and android manages the whole process (synchronization, retry, messages...). Think of this as a 'master' data, that anyone can modify, and if a device has a different data, it is updated and notified (at that moment or when connection is restored).
One possible disadvantage is that the message is sent to all devices (the current code filters those with the app) but the data is just 2 bytes, same size as a string of one character, so it is virtually irrelevant.

The other difference is that, with these data-items, the device that changes the data receives a notification. This is not an issue as the app is already expecting these: currently a message is sent, the other device changes and sends another message, then the first device sees the state is the same and does nothing. With this new method a device changes the data, both devices receives the message, the first device is already in that state so it ignores it, and the second changes the state but not the data.
The only change needed was to filter the special '5/6' event in the phone, as it is now received (fun fact: with the current version, if you have two phones or phone+tablet you will also receive that invalid message and the app will silently crash).

I've been using this version for a couple weeks now and it works as expected (the state is synchronized no matter what). On my watch however the bedtime mode is not working, so I couldn't test it. The code has not changed in that regards, so it should still work, but it would be better to test it just in case.

Note: the code can be now simplified to adapt better to the data instead of messages (for example using two different datas, one for dnd and another for bed) but I tried to keep the changes to a minimum. I may do those change later in a different branch.