### PR TITLE
Localize strings used to determine bedtime status

### DIFF
--- a/mobile/src/main/java/de/rhaeus/dndsync/DNDNotificationService.java
+++ b/mobile/src/main/java/de/rhaeus/dndsync/DNDNotificationService.java
@@ -44,10 +44,12 @@ public class DNDNotificationService extends NotificationListenerService {
             String title = sbn.getNotification().extras.getString("android.title");
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
             boolean syncBedTime = prefs.getBoolean("bedtime_sync_key", true);
-            if(syncBedTime && (title.contains("on") || title.contains("paused"))) {
+            String bedTimeOn = getString(R.string.digital_wellbeing_bedtime_on);
+            String bedTimePaused = getString(R.string.digital_wellbeing_bedtime_paused);
+            if(syncBedTime && (title.contains(bedTimeOn) || title.contains(bedTimePaused))) {
                 int updatedInterruptionFilter;
                 //BedTime
-                if (title.contains("paused")) {
+                if (title.contains(bedTimePaused)) {
                     updatedInterruptionFilter = (interruptionFilter == 5) ? 6 : 5;
                 } else {
                     updatedInterruptionFilter = interruptionFilter;

--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- BedTime strings -->
+    <string name="digital_wellbeing_bedtime_on">aktiviert</string>
+    <string name="digital_wellbeing_bedtime_paused">pausiert</string>
+</resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -13,4 +13,7 @@
     <string name="sync_title">Sync DND state to watch</string>
     <string name="sync_bedtime_title">Sync Bedtime mode to watch</string>
 
+    <!-- BedTime strings -->
+    <string name="digital_wellbeing_bedtime_on">on</string>
+    <string name="digital_wellbeing_bedtime_paused">paused</string>
 </resources>


### PR DESCRIPTION
This addresses #7 by adding localized strings to determine the current bedtime status from the digital wellbeing notification. For now, I added only German translations, since those are the only ones I know.